### PR TITLE
Fix MacOS paths in DLL resolver

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <AssemblyVersion>3.0.0.1</AssemblyVersion>
-    <FileVersion>3.0.0.1</FileVersion>
+    <AssemblyVersion>3.0.0.2</AssemblyVersion>
+    <FileVersion>3.0.0.2</FileVersion>
     
     <Nullable>enable</Nullable>
     <NullableContextOptions>enable</NullableContextOptions>

--- a/ZMusicWrapper/ZMusic.cs
+++ b/ZMusicWrapper/ZMusic.cs
@@ -23,8 +23,8 @@
                          : "runtimes\\win-x86\\native\\"
                      : OperatingSystem.IsMacOS()
                         ? Environment.Is64BitProcess
-                            ? "runtimes\\osx-arm64\\native\\"
-                            : "runtimes\\osx-arm64\\native\\"
+                            ? "runtimes/osx-arm64/native/"
+                            : "runtimes/osx-arm64/native/"
                         : throw new NotSupportedException("Unsupported OS platform");
 
         private static readonly string[] LibraryNames =


### PR DESCRIPTION
Should use `/` instead of `\`