### PR TITLE
Update dylib bundling on MacOS to use @loader_path

### DIFF
--- a/.github/workflows/buildZMusic.yaml
+++ b/.github/workflows/buildZMusic.yaml
@@ -75,7 +75,7 @@ jobs:
         run: strip build_native/linux-x64/*.so
       - name: Bundle Dependencies (MacOS)
         if: ${{ matrix.rid == 'osx-arm64' }}
-        run: dylibbundler -b -x libzmusic.dylib -d . -p .
+        run: dylibbundler -b -x libzmusic.dylib -d . -p @loader_path
         working-directory: build_native/osx-arm64
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <AssemblyVersion>3.0.0.2</AssemblyVersion>
-    <FileVersion>3.0.0.2</FileVersion>
+    <AssemblyVersion>3.0.0.3</AssemblyVersion>
+    <FileVersion>3.0.0.3</FileVersion>
     
     <Nullable>enable</Nullable>
     <NullableContextOptions>enable</NullableContextOptions>


### PR DESCRIPTION
This should allow "chain" resolution of dependencies when loading from something other than the CWD, such as running a debug build of a .NET application with no RID specified.